### PR TITLE
Add totem of undying death prevention and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+.gradle/
+/build/
+/run/
+
+# IDE / tooling
+.idea/
+*.iml
+.classpath
+.project
+.settings/
+.vscode/
+
+# OS files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+desktop.ini
+
+# Logs / temp
+*.log
+*.tmp
+*.swp
+*.swo
+
+# Generated artifacts
+/out/
+/bin/
+/dist/
+
+# Fabric / Loom cache
+remappedSrc/
+remappedMods/
+*.mcassets


### PR DESCRIPTION
Details

Der Death-Handler wurde so angepasst, dass er frühzeitig aussteigt, wenn ein Tod in der Nähe durch ein ausgerüstetes Totem of Undying (Bond007.java (Zeile 107)) verhindert wird. Dadurch wird verhindert, dass das Plugin einen Tod aufzeichnet, den Spieler in den Zuschauer-Modus versetzt oder einen Wiederbelebungs-Timer startet, wenn das Totem ihn retten wird.
Es wurde „shouldIgnoreDeathDueToTotem” hinzugefügt, das die Vanilla-Regeln widerspiegelt (Totems helfen nur, wenn sie sich nicht in der Leere befinden und in einer der Hände gehalten werden), um die Logik zentralisiert und lesbar zu halten (Bond007.java (Zeile 148)). Unterstützende Importe für DamageTypes, Hand, ItemStack und Items wurden am Anfang der Datei hinzugefügt.

(VibeCodeing)